### PR TITLE
Use environment var exported by Wercker

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -10,7 +10,7 @@ npm_setup() {
     npm config set cache "$WERCKER_CACHE_DIR/wercker/npm"
   fi
 
-  if [ -z "${NPM_CONFIG_ACCESS}" ]; then
+  if [ -z "${WERCKER_NPM_CONFIG_ACCESS}" ]; then
     export NPM_CONFIG_ACCESS=public
     npm config set access public
   else

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,3 +1,3 @@
 name: npm-publish
-version: 2.0.2
+version: 2.0.3
 description: npm-publish step


### PR DESCRIPTION
Private publishing is currently broken, because `NPM_CONFIG_ACCESS` is never exported. This PR switches to the exported `WERCKER_NPM_CONFIG_ACCESS`.